### PR TITLE
Update Paypal logo without white background

### DIFF
--- a/assets/images/paypal.svg
+++ b/assets/images/paypal.svg
@@ -1,13 +1,1 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 24.3.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 20 20" style="enable-background:new 0 0 20 20;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:#FFFFFF;}
-</style>
-	<rect class="st0" width="20" height="20"/>
-	<path d="M11.1,3H5.9C5.4,3,5.2,3.3,5.1,3.5L3,15.9c0,0.2,0.1,0.4,0.4,0.4h3.2L7.4,12c0-0.1,0-0.1,0-0.2c0,0,0,0,0,0
-	c0.1-0.3,0.4-0.5,0.7-0.5h1.5c0.3,0,0.6,0,0.9,0c2.2-0.2,4.5-1.2,5-4.4c0,0,0,0,0,0c0,0,0,0,0-0.1C16.1,3.9,13.8,3,11.1,3z"/>
-	<path d="M8.3,12.3l-0.9,5h-1l0,0.2c0,0.2,0.1,0.4,0.4,0.4h2.5c0.5,0,0.7-0.1,0.8-0.5l0.5-3c0.1-0.4,0.3-0.6,0.7-0.6h0.4
-	c0.8,0,4.5,0,5.1-3.8c0.2-1.1,0-2-0.4-2.5c-0.4,1.9-1.4,3.1-2.7,3.9c-1.3,0.8-2.9,1-4.2,1H8.3z"/>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" width="20" height="20" fill="#C6C9CA"><path d="M11.1 3H5.9c-.5 0-.7.3-.8.5L3 15.9c0 .2.1.4.4.4h3.2l.8-4.3v-.2c.1-.3.4-.5.7-.5h2.4c2.2-.2 4.5-1.2 5-4.4v-.1c.6-2.9-1.7-3.8-4.4-3.8z"></path><path d="M8.3 12.3l-.9 5h-1v.2c0 .2.1.4.4.4h2.5c.5 0 .7-.1.8-.5l.5-3c.1-.4.3-.6.7-.6h.4c.8 0 4.5 0 5.1-3.8.2-1.1 0-2-.4-2.5-.4 1.9-1.4 3.1-2.7 3.9-1.3.8-2.9 1-4.2 1l-1.2-.1z"></path></svg>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
- Updated PayPal logo. The updated logo doesn't have a white background

### Fixed Issues
$ https://github.com/Expensify/App/issues/5581

### Tests
1. When not hovering over the PayPal
![image](https://user-images.githubusercontent.com/26411488/135722011-c3196618-1d65-4cf6-b7e1-3f26b7dde5eb.png)
2. When hovering over PayPal, there is no white background, solves the issues
![image](https://user-images.githubusercontent.com/26411488/135722027-f5d5493c-743e-4b82-8e36-4ab45a5775e1.png)

### QA Steps
1. Go to settings
2. Click on `Payments`
3. Click `Add payment method`
4. Hover over `PayPal.me`

### Tested On

- [x] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [ ] Android

### Screenshots
<!-- Add screenshots for all platforms tested. Pull requests won't be merged unless the screenshots show the app was tested on all platforms.-->

#### Web
![image](https://user-images.githubusercontent.com/26411488/135722109-c4b846a1-a2aa-42a6-8adf-bbb6ac11d399.png)

#### Mobile Web
<!-- Insert screenshots of your changes on the web platform (from a mobile browser)-->

#### Desktop
<!-- Insert screenshots of your changes on the desktop platform-->

#### iOS
<!-- Insert screenshots of your changes on the iOS platform-->

#### Android
<!-- Insert screenshots of your changes on the Android platform-->
